### PR TITLE
Fix: `limit` argument for aggregates was not supported

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@myetherwallet/mewconnect-web-client": "^2.1.16",
     "@quasar/extras": "^1.0.0",
     "@walletconnect/web3-provider": "^1.3.1",
-    "aleph-js": "^0.5.0",
+    "aleph-js": "^0.5.1",
     "axios": "^0.21.1",
     "core-js": "^3.6.5",
     "dropzone": "^5.8.1",


### PR DESCRIPTION
This caused issues when fetching large aggregates, such as the network nodes.