### PR TITLE
Read properties of null error caused by forget message fixed 

### DIFF
--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -125,7 +125,7 @@ export default {
     total_used (state) {
       let value = 0
       for (let item of state.stored) {
-        value = value + item.content.size
+        value = value + item.content?.size
       }
       return value / (1024 ** 2)
     }

--- a/src/pages/IPFSPin.vue
+++ b/src/pages/IPFSPin.vue
@@ -189,7 +189,7 @@ export default {
     },
     displayed_stores (state) {
       let ipfs_stores = this.stored.filter(
-        item => item.content.item_type === 'ipfs'
+        item => item.content?.item_type === 'ipfs'
       )
       if (this.tab === 'active') {
         return ipfs_stores.filter(


### PR DESCRIPTION
**Fix:** Once a message is forgotten its content becomes _null_ and therefore no longer accessible. The current application does not take into account the _null_ contents and therefore makes the application crash completely. (c.f issue #36)

**Solution:** Added question mark "?" before accessing to the content element