### PR TITLE
Upgrade CI workflow to fix platform and upload on IPFS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,6 +48,8 @@ jobs:
 
   build:
     runs-on: ubuntu-22.04
+    needs: [lint,tests]
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -62,6 +64,11 @@ jobs:
 
       - name: Build
         run: npx quasar build
+
+      - name: Upload the build on an IPFS node
+        run: |
+          pip install 'aioipfs>=0.6.2'
+          python3 ./upload_build.py
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,13 +13,15 @@ defaults:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
 
       - name: Install dependencies
         run: yarn install
@@ -28,13 +30,15 @@ jobs:
         run: yarn lint
 
   tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
 
       - name: Install dependencies
         run: yarn install
@@ -43,13 +47,15 @@ jobs:
         run: yarn test
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
 
       - name: Install dependencies
         run: yarn install

--- a/upload_build.py
+++ b/upload_build.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+"""
+This script uploads the build SPA to IPFS.
+
+It does not ping it or do anything else yet, so the result can only be accessed
+ as long as the files are not garbage collected.
+
+Requires: 'aioipfs>=0.6.2'
+"""
+
+import asyncio
+import aioipfs
+
+
+async def add_files(files: list):
+    client = aioipfs.AsyncIPFS(maddr="/dns4/ipfs-2.aleph.im/tcp/443/https")
+
+    async for added_file in client.add(*files, recursive=True):
+        print(f"Imported file {added_file['Name']}, CID: {added_file['Hash']}")
+
+    await client.close()
+
+
+asyncio.run(add_files(["dist/spa"]))


### PR DESCRIPTION
This branch contains two commits that should not be squashed:

1. The first fixes the version of Ubuntu and Node used by the builds
2. The second uploads the build to IPFS using the IPFS service provided by Aleph IPFS nodes and [described here](https://github.com/aleph-im/aleph-infra/blob/main/aleph/infra/services/ipfs/README.md).

This only makes the hash available in the logs of GitHub Actions and does not pin it anywhere, but I believe it is a good start to build the CD pipeline.

CI builds are now dependent on the `lint` and `tests` in order to avoid publishing useless builds.

![image](https://user-images.githubusercontent.com/404665/205704602-2ef89d1c-418f-4b90-9561-7547aaf54d30.png)

![image](https://user-images.githubusercontent.com/404665/205704756-08295cc5-8da4-4280-b2e3-da2012f06425.png)
(...)
![image](https://user-images.githubusercontent.com/404665/205704827-2908ee33-41a7-46a7-87ef-0b5c30f9aa7e.png)
