### PR TITLE
Feat: Display last git tag on the UI

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,3 +4,4 @@
 /src-cordova
 /.quasar
 /node_modules
+quasar.conf.js

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -44,7 +44,8 @@ module.exports = {
     __statics: true,
     process: true,
     Capacitor: true,
-    chrome: true
+    chrome: true,
+    GIT_DESCRIBE_TAGS: true
   },
 
   // add your custom rules here

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,7 @@ name: Tests
 on:
   push:
     branches: ["*"]
+    tags: '*'
   pull_request:
     branches: ["*"]
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,6 +53,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      
+      - name: Get git context
+        run: git fetch --prune --unshallow
 
       - name: Setup node
         uses: actions/setup-node@v3

--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -71,9 +71,8 @@ module.exports = function (/* ctx */) {
 
       // https://quasar.dev/quasar-cli/handling-webpack
       extendWebpack (cfg) {
-        if(!cfg.plugins)
-          cfg.plugins = []
-        
+        if (!cfg.plugins) { cfg.plugins = [] }
+
         cfg.plugins.push(
           new webpack.DefinePlugin({
             GIT_DESCRIBE_TAGS: JSON.stringify(GIT_DESCRIBE_TAGS)

--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -7,6 +7,10 @@
 // https://quasar.dev/quasar-cli/quasar-conf-js
 /* eslint-env node */
 
+const { execSync } = require('child_process')
+const GIT_DESCRIBE_TAGS = execSync('git describe --tags').toString()
+const webpack = require('webpack')
+
 module.exports = function (/* ctx */) {
   return {
     // https://quasar.dev/quasar-cli/supporting-ts
@@ -67,6 +71,15 @@ module.exports = function (/* ctx */) {
 
       // https://quasar.dev/quasar-cli/handling-webpack
       extendWebpack (cfg) {
+        if(!cfg.plugins)
+          cfg.plugins = []
+        
+        cfg.plugins.push(
+          new webpack.DefinePlugin({
+            GIT_DESCRIBE_TAGS: JSON.stringify(GIT_DESCRIBE_TAGS)
+          })
+        )
+
         cfg.module.rules.push({
           enforce: 'pre',
           test: /\.(js|vue)$/,

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -130,18 +130,7 @@
               <q-linear-progress :value="total_used / allowance" class="q-my-sm" rounded />
             </q-item-section>
           </q-item>
-          <q-item v-if="app_version">
-            <q-item-label caption v-if="last_release_is_a_tag()">
-              <a style="color:inherit"
-                :href="('https://github.com/aleph-im/aleph-account/tree/' + app_version)">
-                v{{ app_version }}
-              </a>
-            </q-item-label>
-            <q-item-label caption v-else>
-              v{{ app_version }}
-            </q-item-label>
-            &nbsp;
-          </q-item>
+
         </q-list>
       </div>
     </q-drawer>
@@ -149,9 +138,21 @@
       <router-view />
     </q-page-container>
 
-    <q-footer :class="($q.dark.isActive?'text-white':'text-black') + ' bg-transparent q-pa-sm q-pt-lg'">
-      <p style="font-size: 0.9em; margin-bottom: 10px; opacity: 0.3;">
+    <q-footer :class="($q.dark.isActive?'text-white':'text-black') + ' bg-transparent q-pa-sm q-pt-lg row justify-between'"
+              style="font-size: 0.9em; margin-bottom: 10px; opacity: 0.3;">
+      <p>
         Copyright ©2020-present <a href="https://aleph.im/" :class="($q.dark.isActive?'text-white':'text-black')">aleph.im project</a>, all rights reserved.
+      </p>
+      <p v-if="app_version">
+        <span caption v-if="last_release_is_a_tag()">
+          <a style="color:inherit" :href="('https://github.com/aleph-im/aleph-account/tree/' + app_version)">
+            v{{ app_version }}
+          </a>
+        </span>
+        <span caption v-else>
+          v{{ app_version }}
+        </span>
+        &nbsp;
       </p>
     </q-footer>
 

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -448,7 +448,7 @@ export default {
     this.update_distributions()
     this.prepare_distributions_feed()
 
-    if(!GIT_DESCRIBE_TAGS){
+    if (!GIT_DESCRIBE_TAGS) {
       console.warn(`
 No build version detected.
 This bundle was probably not built from a git repository,

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -10,6 +10,13 @@
             <img v-if="(!left)&&$q.dark.isActive" src="~/assets/logo-white.svg" height="32">
             <span class="q-ml-sm">
                 aleph.im
+                <span class="text-subtitle2">
+                  &nbsp;
+                  <a :class="($q.dark.isActive?'text-white':'text-black')"
+                     :href="('https://github.com/aleph-im/aleph-account/tree/' + app_version)">
+                     {{ app_version }}
+                  </a>
+                </span>
             </span>
         </q-toolbar-title>
         <q-space />
@@ -197,6 +204,7 @@ export default {
   },
   data () {
     return {
+      app_version: GIT_DESCRIBE_TAGS,
       web3ConnectModal: false,
       ellipseAddress: ellipseAddress,
       left: false,

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -12,10 +12,15 @@
                 aleph.im
                 <span class="text-subtitle2">
                   &nbsp;
-                  <a :class="($q.dark.isActive?'text-white':'text-black')"
-                     :href="('https://github.com/aleph-im/aleph-account/tree/' + app_version)">
-                     {{ app_version }}
-                  </a>
+                  <template v-if="last_release_is_a_tag()">
+                    <a :class="($q.dark.isActive?'text-white':'text-black')"
+                      :href="('https://github.com/aleph-im/aleph-account/tree/' + app_version)">
+                      {{ app_version }}
+                    </a>
+                  </template>
+                  <template v-else>
+                    {{ app_version }}
+                  </template>
                 </span>
             </span>
         </q-toolbar-title>
@@ -296,6 +301,9 @@ export default {
         console.error('Socket encountered error: ', err.message, 'Closing socket')
         statusSocket.close()
       }
+    },
+    last_release_is_a_tag () {
+      return /\d+-.[0-9A-F]{7}$/i.test(this.app_version)
     },
     async update_distributions () {
       let result = await posts.get_posts(

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -10,20 +10,6 @@
             <img v-if="(!left)&&$q.dark.isActive" src="~/assets/logo-white.svg" height="32">
             <span class="q-ml-sm">
                 aleph.im
-                <span class="text-subtitle2">
-                  <template v-if="app_version">
-                    &nbsp;
-                    <template v-if="last_release_is_a_tag()">
-                      <a :class="($q.dark.isActive?'text-white':'text-black')"
-                        :href="('https://github.com/aleph-im/aleph-account/tree/' + app_version)">
-                        {{ app_version }}
-                      </a>
-                    </template>
-                    <template v-else>
-                      {{ app_version }}
-                    </template>
-                  </template>
-                </span>
             </span>
         </q-toolbar-title>
         <q-space />
@@ -144,6 +130,18 @@
               <q-linear-progress :value="total_used / allowance" class="q-my-sm" rounded />
             </q-item-section>
           </q-item>
+          <q-item v-if="app_version">
+            <q-item-label caption v-if="last_release_is_a_tag()">
+              <a style="color:inherit"
+                :href="('https://github.com/aleph-im/aleph-account/tree/' + app_version)">
+                v{{ app_version }}
+              </a>
+            </q-item-label>
+            <q-item-label caption v-else>
+              v{{ app_version }}
+            </q-item-label>
+            &nbsp;
+          </q-item>
         </q-list>
       </div>
     </q-drawer>
@@ -152,7 +150,9 @@
     </q-page-container>
 
     <q-footer :class="($q.dark.isActive?'text-white':'text-black') + ' bg-transparent q-pa-sm q-pt-lg'">
-      <p style="font-size: 0.9em; margin-bottom: 10px; opacity: 0.3;">Copyright ©2020-present <a href="https://aleph.im/" :class="($q.dark.isActive?'text-white':'text-black')">aleph.im project</a>, all rights reserved.</p>
+      <p style="font-size: 0.9em; margin-bottom: 10px; opacity: 0.3;">
+        Copyright ©2020-present <a href="https://aleph.im/" :class="($q.dark.isActive?'text-white':'text-black')">aleph.im project</a>, all rights reserved.
+      </p>
     </q-footer>
 
   </q-layout>


### PR DESCRIPTION
Displays the git tag the build is based on  as a clickable link to github on the UI. If the branch has commits since the last tag, it is suffixed by the commit hash and a simple `<span>` tag instead of a link.

closes #50 

## Light mode
![Capture d’écran du 2022-12-06 13-48-21](https://user-images.githubusercontent.com/26065817/205917505-12ea325c-b937-40b5-a3c1-6ae3a45d7414.png)

## Dark mode
![Capture d’écran du 2022-12-06 13-48-16](https://user-images.githubusercontent.com/26065817/205917508-7991b605-a7f1-4cf1-9847-3e3b4c338009.png)

## Dark mode (commits since previous tag)
![Capture d’écran du 2022-12-06 14-34-03](https://user-images.githubusercontent.com/26065817/205926805-f6c88317-715b-4107-b2eb-0b1032d9292a.png)

## Pitfall

Since the tag is injected during the first compilation by webpack, if you do some git manipulation (create a branch, commit, ...) during quasar hot-reload the changes won't be reflected unless you manually stop and restart quasar. 

