### PR TITLE
chore: remove solana connect button from the UI

### DIFF
--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -14,7 +14,7 @@
         </q-toolbar-title>
         <q-space />
         <q-btn-group class="shadow-1 bg-aleph-radial">
-          <q-btn v-if="!account" size="md" class="bg-aleph-radial text-white" @click="web3ConnectModal = true">Connect to a wallet</q-btn>
+          <q-btn v-if="!account" size="md" class="bg-aleph-radial text-white" @click="ethWeb3Connect('metamask')">Connect to a wallet</q-btn>
           <q-dialog v-model="web3ConnectModal">
             <q-card style="width: 550px">
               <q-card-section>


### PR DESCRIPTION
Removing the ability to connect from anything else than Metamask (or any other eth built-in browser wallet), until Solana staking is fully functional.