### PR TITLE
Label in NFT Storage section exceeds cell

### DIFF
--- a/src/pages/NFTStorage.vue
+++ b/src/pages/NFTStorage.vue
@@ -31,8 +31,8 @@
                  class="full-width" controls autoplay loop
                  v-else-if="item.content.metadata.animation_url" />
 
-            <q-card-section v-if="item.content.metadata.name">
-              <div class="text-h6">{{item.content.metadata.name.substring(0, 100)}}</div>
+            <q-card-section :style="'overflow-wrap: break-word;'" v-if="item.content.metadata.name">
+              <div class="text-h6"> {{item.content.metadata.name.substring(0, 100)}}</div>
               <div class="text-subtitle2">
                 Snapshot from {{new Date(item.time*1000).toLocaleDateString()}}
               </div>


### PR DESCRIPTION
Issue. #61  Fixed

I added break-word style to label:

```
:style="'overflow-wrap: break-word;'"
```

<img width="389" alt="Screenshot" src="https://user-images.githubusercontent.com/17054452/212647251-514aefc5-2336-4ffd-a165-36090e99a9a4.png">
