### PR TITLE
fix: Copy to clipboard not working on Firefox

### DIFF
--- a/src/components/NodeInfo.vue
+++ b/src/components/NodeInfo.vue
@@ -223,7 +223,8 @@ import { mapState } from 'vuex'
 import { posts, store } from 'aleph-js'
 import ResourceNodeName from './ResourceNodeName.vue'
 import CoreNodeName from './CoreNodeName.vue'
-import { copyToClipboard, ellipseAddress } from '../helpers/utilities'
+import { ellipseAddress } from '../helpers/utilities'
+import { copyToClipboard } from 'quasar'
 
 export default {
   components: { ResourceNodeName, CoreNodeName },

--- a/src/helpers/utilities.js
+++ b/src/helpers/utilities.js
@@ -1,5 +1,3 @@
-import { Notify } from 'quasar'
-
 // FIXME
 // Potential dupplicate of "text-overflow: ellipsis" property
 // https://developer.mozilla.org/en-US/docs/Web/CSS/text-overflow
@@ -41,22 +39,4 @@ export function convertTimestamp (timestamp) {
 
 export function ellipseAddress (address, width = 10) {
   return `${address.slice(0, width)}...${address.slice(-width)}`
-}
-
-export async function copyToClipboard (text) {
-  const clipboardPermission = await navigator.permissions.query({ name: 'clipboard-write' })
-  const notifyOptions = {
-    position: 'top',
-    timeout: 5000,
-    message: 'Copied to clipboard'
-  }
-
-  if (clipboardPermission.state === 'granted' || clipboardPermission.state === 'prompt') {
-    await navigator.clipboard.writeText(text)
-  } else {
-    notifyOptions.message = 'Unable to access the clipboard'
-    notifyOptions.color = 'negative'
-  }
-
-  return Notify.create(notifyOptions)
 }


### PR DESCRIPTION
# Problem
The copy to clipboard on Node infos was not working on Firefox

# Solution 
Use quasar helpers which handle all the behaviors and remove homemade helper function.