### PR TITLE
fix: IPFS pinning lockfile error

### DIFF
--- a/src/boot/ipfs.js
+++ b/src/boot/ipfs.js
@@ -2,8 +2,10 @@ import IPFS from 'ipfs'
 import Vue from 'vue'
 
 const plugin = {
-  install (Vue, opts = {}) {
-    Vue.prototype.$ipfs = IPFS.create(opts)
+
+  async install (Vue, opts = {}) {
+    const IPFS_instance = await IPFS.create(opts)
+    Vue.prototype.$ipfs = IPFS_instance
   }
 }
 

--- a/src/pages/IPFSPin.vue
+++ b/src/pages/IPFSPin.vue
@@ -156,7 +156,6 @@ import { store, aggregates } from 'aleph-js'
 import { format, copyToClipboard } from 'quasar'
 const { humanStorageSize } = format
 
-import IPFS from 'ipfs'
 const isIPFS = require('is-ipfs')
 
 function sleep (ms) {
@@ -358,7 +357,7 @@ export default {
     this.$store.dispatch('update_store_info')
   },
   async created () {
-    this.node = await IPFS.create()
+    this.node = this.$ipfs
   },
   watch: {
     account (account) {

--- a/src/pages/NFTStorage.vue
+++ b/src/pages/NFTStorage.vue
@@ -70,7 +70,6 @@ import { posts } from 'aleph-js'
 import { update_post } from '../services/posts'
 const { humanStorageSize } = format
 
-import IPFS from 'ipfs'
 import NftSnapshot from 'src/components/NftSnapshot.vue'
 function sleep (ms) {
   return new Promise(resolve => setTimeout(resolve, ms))
@@ -176,7 +175,7 @@ export default {
     this.update()
   },
   async created () {
-    this.node = await IPFS.create()
+    this.node = this.$ipfs
   },
   watch: {
     account (account) {


### PR DESCRIPTION
The problem came from a double instantiation of IPFS. It was once instantiated as a plugin (to be used accross the whole app) and tried to be reinstanciated on page mount (on IPFS pinning and NFT storage) leading to a lockfile error

close #10 