### PR TITLE
Fix future IPFS Pinning regression on postgres based Nodes

### DIFF
--- a/src/components/NftSnapshot.vue
+++ b/src/components/NftSnapshot.vue
@@ -220,12 +220,8 @@ export default {
       }
       return 0
     },
-    total_used () {
-      let value = 0
-      for (let item of this.stored) {
-        value = value + item.content.size
-      }
-      return value / (1024 ** 2)
+    total_used (state) {
+      return state.stored_total / (1024 ** 2)
     },
     to_store_size () {
       let size = 0

--- a/src/helpers/utilities.js
+++ b/src/helpers/utilities.js
@@ -40,3 +40,26 @@ export function convertTimestamp (timestamp) {
 export function ellipseAddress (address, width = 10) {
   return `${address.slice(0, width)}...${address.slice(-width)}`
 }
+
+/**
+ * Use to copy an element from on array to the other based on a key.
+ * Transforms a O(n^2) into a O(2n) operation
+ *
+ * @param {Array} origin An array to copy value from
+ * @param {Function} originAccessor A function that retrieves a key in `origin`
+ * @param {Array} destination The copy destination
+ * @param {Function} destinationAccessor A function that retrieves a key in `replaceTo`
+ * @param {Function} joinCallback A function that takes a value with the same key from `origin` and `destination` and outputs an object
+ */
+export function joinArrays (origin, originAccessor, destination, destinationAccessor, joinCallback) {
+  const hashMap = new Map()
+  for (const item of origin) {
+    const hashMapKey = originAccessor(item)
+    hashMap.set(hashMapKey, item)
+  }
+
+  return destination.map((x, i) => {
+    const hashMapKey = destinationAccessor(x)
+    return joinCallback(hashMap.get(hashMapKey), x, hashMapKey, i)
+  })
+}

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -201,11 +201,7 @@ export default {
       return 0
     },
     total_used (state) {
-      let value = 0
-      for (let item of state.stored) {
-        value = value + item.content?.size
-      }
-      return value / (1024 ** 2)
+      return state.stored_total / (1024 ** 2)
     }
   }),
   watch: {

--- a/src/pages/IPFSPin.vue
+++ b/src/pages/IPFSPin.vue
@@ -180,11 +180,7 @@ export default {
       return 0
     },
     total_used (state) {
-      let value = 0
-      for (let item of state.stored) {
-        value = value + item.content.size
-      }
-      return value / (1024 ** 2)
+      return state.stored_total / (1024 ** 2)
     },
     displayed_stores (state) {
       let ipfs_stores = this.stored.filter(

--- a/src/pages/IPFSPin.vue
+++ b/src/pages/IPFSPin.vue
@@ -20,6 +20,7 @@
 
         <q-card-section v-if="cid_info">
           <b>Type:</b> {{cid_info.type}}<br />
+          <b>Size:</b> {{humanStorageSize(cid_info.cumulativeSize)}}
         </q-card-section>
 
         <q-card-actions align="right" class="text-primary">

--- a/src/pages/IPFSPin.vue
+++ b/src/pages/IPFSPin.vue
@@ -20,7 +20,6 @@
 
         <q-card-section v-if="cid_info">
           <b>Type:</b> {{cid_info.type}}<br />
-          <b>Size:</b> {{humanStorageSize(cid_info.cumulativeSize)}}
         </q-card-section>
 
         <q-card-actions align="right" class="text-primary">
@@ -186,6 +185,7 @@ export default {
       let ipfs_stores = this.stored.filter(
         item => item.content?.item_type === 'ipfs'
       )
+
       if (this.tab === 'active') {
         return ipfs_stores.filter(
           item => (

--- a/src/pages/NFTStorage.vue
+++ b/src/pages/NFTStorage.vue
@@ -103,11 +103,7 @@ export default {
       return 0
     },
     total_used (state) {
-      let value = 0
-      for (let item of state.stored) {
-        value = value + item.content.size
-      }
-      return value / (1024 ** 2)
+      return state.stored_total / (1024 ** 2)
     }
   }),
   components: {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -94,7 +94,7 @@ export default new Vuex.Store({
     },
     set_stored (state, { files, total }) {
       state.stored = files
-      state.stored_total = total || files.reduce((ac, cv) => (ac += cv?.content?.size || 0), 0)
+      state.stored_total = total
     },
     update_note (state, new_note) {
       for (const note of state.notes) {
@@ -324,7 +324,12 @@ export default new Vuex.Store({
               api_server: state.api_server
               // channel: 'PINNING'
             })
-          if (items.messages) { commit('set_stored', items.messages) }
+          if (items.messages) {
+            commit('set_stored', {
+              files: items.messages,
+              total: items.messages.reduce((ac, cv) => (ac += cv?.content?.size || 0), 0)
+            })
+          }
         }
       }
     }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -8,6 +8,7 @@ import {
 import { decrypt_content } from '../services/encryption.js'
 import { get_erc20_balance } from '../services/erc20.js'
 import axios from 'axios'
+import { joinArrays } from 'src/helpers/utilities'
 
 var providers = require('ethers').providers
 
@@ -323,23 +324,16 @@ export default new Vuex.Store({
           // Postgres API
           const { data } = await axios.get(`${state.api_server}/api/v0/addresses/${state.account.address}/files?pagination=1000`)
           total_size = data?.total_size
-          const stack = [...data.files]
-          files = files.map(file => {
-            const stackIndex = stack.findIndex(fileInStack => fileInStack.item_hash === file.item_hash)
-            let size = 0
-            if (stackIndex !== -1) {
-              size = stack[stackIndex]?.size
-              stack.splice(stackIndex, 1)
-            }
-            return {
-              ...file,
-              content: {
-                ...file.content,
-                size
-              }
+
+          const getItemHash = x => x.item_hash
+          const replacementCallback = (from, to) => ({
+            ...to,
+            content: {
+              ...to.content,
+              size: from.size || 0
             }
           })
-          console.log(files)
+          files = joinArrays(data.files, getItemHash, files, getItemHash, replacementCallback)
         } catch (error) {
           console.log('Files API is not yet implemented on the node')
         }


### PR DESCRIPTION
# Description

This PR intends to fix a regression that will occur when the PostgreSQL API is live on pyaleph. `STORE` message won't display file size anymore. To solve this issues, file sizes will be fetched on a separate endpoint and merged at display. 

**This PR has no effect when using the current API**

# Source and additional context

Here is the same store message on current API and a Node using the new postgresql implementation:
- [bebe11d38...eb3 on api.aleph.im](https://api2.aleph.im/api/v0/messages.json?hashes=bebe11d38468527a4dfbb232554b8c55eab688c2cf572e0ed06f80548bdf7eb3)
- [bebe11d38...eb3 on a postgresql node](http://163.172.70.92:8000/api/v0/messages.json?hashes=bebe11d38468527a4dfbb232554b8c55eab688c2cf572e0ed06f80548bdf7eb3)

Notice that the `size` key is missing on the latter. To fix this, we use the new `/api/v0/addresses/files` endpoint to retrieve the missing information.

# Misc. fix

It also fixes the way the current `used` space is calculated, it was previously computed on client side, by summing the size of store message posted on the `PINNING` channel, this had several caveat (ie.: the used space relied on the number of fetched items). It is now directly returned by the API on `/api/v0/addresses/files`

![image](https://user-images.githubusercontent.com/26065817/215675718-6f86ea46-c09c-40ce-b426-33ec8e9549ac.png)
