### PR TITLE
(perf) Removes double lookup on array replacement

### DIFF
--- a/src/helpers/utilities.js
+++ b/src/helpers/utilities.js
@@ -40,3 +40,26 @@ export function convertTimestamp (timestamp) {
 export function ellipseAddress (address, width = 10) {
   return `${address.slice(0, width)}...${address.slice(-width)}`
 }
+
+/**
+ * Use to copy an element from on array to the other based on a key.
+ * Transforms a O(n^2) into a O(2n) operation
+ *
+ * @param {Array} replaceFrom An array to copy value from
+ * @param {Function} accessorFrom A function that retrieves a key in `replaceFrom`
+ * @param {Array} replaceInto The copy destination
+ * @param {Function} accessorInto A function that retrieves a key in `replaceTo`
+ * @param {Function} replacementCallback A function that should output an object
+ */
+export function hashmapReplace (replaceFrom, accessorFrom, replaceInto, accessorInto, replacementCallback) {
+  const hashMap = {}
+  for (const i of replaceFrom) {
+    const hashMapKey = accessorFrom(i)
+    hashMap[hashMapKey] = i
+  }
+
+  return replaceInto.map((x, i) => {
+    const hashMapKey = accessorInto(x)
+    return replacementCallback(hashMap[hashMapKey], x, hashMapKey, i)
+  })
+}

--- a/src/helpers/utilities.js
+++ b/src/helpers/utilities.js
@@ -45,21 +45,21 @@ export function ellipseAddress (address, width = 10) {
  * Use to copy an element from on array to the other based on a key.
  * Transforms a O(n^2) into a O(2n) operation
  *
- * @param {Array} replaceFrom An array to copy value from
- * @param {Function} accessorFrom A function that retrieves a key in `replaceFrom`
- * @param {Array} replaceInto The copy destination
- * @param {Function} accessorInto A function that retrieves a key in `replaceTo`
- * @param {Function} replacementCallback A function that should output an object
+ * @param {Array} origin An array to copy value from
+ * @param {Function} originAccessor A function that retrieves a key in `origin`
+ * @param {Array} destination The copy destination
+ * @param {Function} destinationAccessor A function that retrieves a key in `replaceTo`
+ * @param {Function} joinCallback A function that takes a value with the same key from `origin` and `destination` and outputs an object
  */
-export function hashmapReplace (replaceFrom, accessorFrom, replaceInto, accessorInto, replacementCallback) {
-  const hashMap = {}
-  for (const i of replaceFrom) {
-    const hashMapKey = accessorFrom(i)
-    hashMap[hashMapKey] = i
+export function joinArrays (origin, originAccessor, destination, destinationAccessor, joinCallback) {
+  const hashMap = new Map()
+  for (const item of origin) {
+    const hashMapKey = originAccessor(item)
+    hashMap.set(hashMapKey, item)
   }
 
-  return replaceInto.map((x, i) => {
-    const hashMapKey = accessorInto(x)
-    return replacementCallback(hashMap[hashMapKey], x, hashMapKey, i)
+  return destination.map((x, i) => {
+    const hashMapKey = destinationAccessor(x)
+    return joinCallback(hashMap.get(hashMapKey), x, hashMapKey, i)
   })
 }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -8,6 +8,7 @@ import {
 import { decrypt_content } from '../services/encryption.js'
 import { get_erc20_balance } from '../services/erc20.js'
 import axios from 'axios'
+import { hashmapReplace } from 'src/helpers/utilities'
 
 var providers = require('ethers').providers
 
@@ -323,22 +324,32 @@ export default new Vuex.Store({
           // Postgres API
           const { data } = await axios.get(`${state.api_server}/api/v0/addresses/${state.account.address}/files?pagination=1000`)
           total_size = data?.total_size
-          const stack = [...data.files]
-          files = files.map(file => {
-            const stackIndex = stack.findIndex(fileInStack => fileInStack.item_hash === file.item_hash)
-            let size = 0
-            if (stackIndex !== -1) {
-              size = stack[stackIndex]?.size
-              stack.splice(stackIndex, 1)
-            }
-            return {
-              ...file,
-              content: {
-                ...file.content,
-                size
-              }
+          // const stack = [...data.files]
+          // files = files.map(file => {
+          //   const stackIndex = stack.findIndex(fileInStack => fileInStack.item_hash === file.item_hash)
+          //   let size = 0
+          //   if (stackIndex !== -1) {
+          //     size = stack[stackIndex]?.size
+          //     stack.splice(stackIndex, 1)
+          //   }
+          //   return {
+          //     ...file,
+          //     content: {
+          //       ...file.content,
+          //       size
+          //     }
+          //   }
+          // })
+          // console.log(files)
+          const getItemHash = x => x.item_hash
+          const replacementCallback = (from, to) => ({
+            ...to,
+            content: {
+              ...to.content,
+              size: from.size || 0
             }
           })
+          files = hashmapReplace(data.files, getItemHash, files, getItemHash, replacementCallback)
           console.log(files)
         } catch (error) {
           console.log('Files API is not yet implemented on the node')

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -8,7 +8,7 @@ import {
 import { decrypt_content } from '../services/encryption.js'
 import { get_erc20_balance } from '../services/erc20.js'
 import axios from 'axios'
-import { hashmapReplace } from 'src/helpers/utilities'
+import { joinArrays } from 'src/helpers/utilities'
 
 var providers = require('ethers').providers
 
@@ -324,7 +324,7 @@ export default new Vuex.Store({
           // Postgres API
           const { data } = await axios.get(`${state.api_server}/api/v0/addresses/${state.account.address}/files?pagination=1000`)
           total_size = data?.total_size
-          
+
           const getItemHash = x => x.item_hash
           const replacementCallback = (from, to) => ({
             ...to,
@@ -333,7 +333,7 @@ export default new Vuex.Store({
               size: from.size || 0
             }
           })
-          files = hashmapReplace(data.files, getItemHash, files, getItemHash, replacementCallback)
+          files = joinArrays(data.files, getItemHash, files, getItemHash, replacementCallback)
         } catch (error) {
           console.log('Files API is not yet implemented on the node')
         }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -324,23 +324,7 @@ export default new Vuex.Store({
           // Postgres API
           const { data } = await axios.get(`${state.api_server}/api/v0/addresses/${state.account.address}/files?pagination=1000`)
           total_size = data?.total_size
-          // const stack = [...data.files]
-          // files = files.map(file => {
-          //   const stackIndex = stack.findIndex(fileInStack => fileInStack.item_hash === file.item_hash)
-          //   let size = 0
-          //   if (stackIndex !== -1) {
-          //     size = stack[stackIndex]?.size
-          //     stack.splice(stackIndex, 1)
-          //   }
-          //   return {
-          //     ...file,
-          //     content: {
-          //       ...file.content,
-          //       size
-          //     }
-          //   }
-          // })
-          // console.log(files)
+          
           const getItemHash = x => x.item_hash
           const replacementCallback = (from, to) => ({
             ...to,
@@ -350,7 +334,6 @@ export default new Vuex.Store({
             }
           })
           files = hashmapReplace(data.files, getItemHash, files, getItemHash, replacementCallback)
-          console.log(files)
         } catch (error) {
           console.log('Files API is not yet implemented on the node')
         }


### PR DESCRIPTION
Introducing a new helper to copy informations from an `origin` array to a `destination` array, when both array have a common key (ex: an `item_hash`). Greatly enhances performance of #81 (and possibly #72 ), by transforming a double array lookup into an hashmap lookup.

https://jsben.ch/N5BI6