### PR TITLE
Add tooltip to toggle explaining "Use latest version" functionality

### DIFF
--- a/src/components/CreateNewVM.vue
+++ b/src/components/CreateNewVM.vue
@@ -108,7 +108,10 @@
               stack-label standout class="q-my-sm" />
           </div>
           <div v-show="!volume.isPersistent">
-            <span>Use latest version?</span>
+            <div class="q-ml-sm">
+              Use latest version
+              <q-icon name="help"  style="font-size: 20px;" class="q-ml-sm"><q-tooltip v-model="showingTooltip">Supervisor will download the new version of the volume and restart the VM.</q-tooltip></q-icon>
+            </div>
             <q-radio v-model="volume.use_latest" :val="true" label="Yes" />
             <q-radio v-model="volume.use_latest" :val="false" label="No" />
           </div>
@@ -198,7 +201,8 @@ export default {
       ],
       selectedLanguage: { label: 'Python 3', value: 'python', available: true },
       step: 1,
-      tab: false
+      tab: false,
+      showingTooltip: false
     }
   },
   computed: {


### PR DESCRIPTION
This PR resolves the issue number #89.

I added `help` icon and tooltip with the following message:

_Supervisor will download the new version of the volume and restart the VM._

![Help icon](https://user-images.githubusercontent.com/17054452/219602283-9f9972d9-4e6f-4a05-80e7-30150aa77492.png)

![Help icon with hover](https://user-images.githubusercontent.com/17054452/219602366-84bc43a9-2b41-4588-b894-b3a714c5c11d.png)



