### PR TITLE
Network errors (Github API, Websockets) do not fully break display

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,15 @@
 <template>
   <div id="q-app" style="padding-top:40px">
-    <div class="scores_disclaimer" v-if="_scores_grace_period_end - Date.now() > 0">
-      <a href="https://medium.com/aleph-im/new-nodes-scoring-on-aleph-network-20a0cfc305fa">Starting from May 4th 2023 (23:59 UTC), our new reward system will be in effect, balancing rewards based on nodes scores.</a>
+    <div class="network_errors" v-if="has_network_errors">
+      <template v-if="network_errors.github">
+        Cannot reach Github API, CCN and CRN versions check are disabled.
+      </template>
+      <template v-if="network_errors.scores">
+        Cannot get score information
+      </template>
+      <template v-if="network_errors.websockets">
+        The websocket API is experiencing issues, live status updates are disabled.
+      </template>
     </div>
 
     <router-view />
@@ -12,9 +20,14 @@ import { mapState } from 'vuex'
 
 export default {
   name: 'App',
-  computed: mapState({
-    _scores_grace_period_end: state => state._scores_grace_period_end
-  })
+  computed: {
+    has_network_errors () {
+      return Object.values(this.network_errors).some(v => v)
+    },
+    ...mapState({
+      network_errors: state => state.network_errors
+    })
+  }
 }
 </script>
 <style lang="scss">
@@ -22,13 +35,13 @@ body.body--dark  {
   background:#1d2a31;
 }
 
-.scores_disclaimer{
+.network_errors{
   padding: 5px;
   display: flex;
   align-items: center;
   justify-content: center;
   color: #FFF;
-  background-color: #0055FF;
+  background-color: #fd686a;
   position: fixed;
   top: 0;
   left: 0;

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,7 +2,7 @@
   <div id="q-app" style="padding-top:40px">
     <div class="network_errors" v-if="has_network_errors">
       <template v-if="network_errors.github">
-        Cannot reach Github API, CCN and CRN versions check are disabled.
+        Cannot reach Github API, the display of the latest release is disabled (rewards are not affected)
       </template>
       <template v-if="network_errors.scores">
         Cannot get score information

--- a/src/components/NodesTable.vue
+++ b/src/components/NodesTable.vue
@@ -352,8 +352,7 @@ export default {
       }
     },
     node_versions_unavailable () {
-      return Object.values(this.latest_releases.ccn).some(x => x === null) ||
-        Object.values(this.latest_releases.crn).some(x => x === null)
+      return this.network_errors.github
     },
     ...mapState({
       account: (state) => state.account,
@@ -367,7 +366,8 @@ export default {
       active_nodes: (state) => state.nodes.filter((node) => node.status === 'active').length,
       total_staked_in_active: (state) => state.nodes.reduce(
         (prev, cur) => prev + (cur.status === 'active' ? cur.total_staked : 0), 0
-      )
+      ),
+      network_errors: (state) => state.network_errors
     })
   },
   components: {

--- a/src/components/NodesTable.vue
+++ b/src/components/NodesTable.vue
@@ -198,18 +198,23 @@
             {{ new Date(props.row.time*1000).toLocaleDateString() }}
           </q-td>
           <q-td key="version" :props="props">
-            <div :style="`color: ${is_node_uptodate(props.row, coreNodeMode) && !is_node_experimental(props.row, coreNodeMode) ? '#1CC272' : is_node_outdated(props.row, coreNodeMode) || is_node_experimental(props.row, coreNodeMode) ? '#FABE23' : '#FD686A'}`">
-              <strong>
+            <template v-if="node_versions_unavailable">
                 {{ props.row?.metrics?.version || '-' }}
-              </strong>
-            </div>
-            <small>
-              <template v-if="is_node_latest(props.row, coreNodeMode)">(latest)</template>
-              <template v-else-if="is_node_prerelease(props.row, coreNodeMode)">(prerelease)</template>
-              <template v-else-if="is_node_experimental(props.row, coreNodeMode)">(experimental)</template>
-              <template v-else-if="is_node_outdated(props.row, coreNodeMode)">(outdated)</template>
-              <template v-else>(obsolete)</template>
-            </small>
+            </template>
+            <template v-else>
+              <div :style="`color: ${is_node_uptodate(props.row, coreNodeMode) && !is_node_experimental(props.row, coreNodeMode) ? '#1CC272' : is_node_outdated(props.row, coreNodeMode) || is_node_experimental(props.row, coreNodeMode) ? '#FABE23' : '#FD686A'}`">
+                <strong>
+                  {{ props.row?.metrics?.version || '-' }}
+                </strong>
+              </div>
+              <small>
+                <template v-if="is_node_latest(props.row, coreNodeMode)">(latest)</template>
+                <template v-else-if="is_node_prerelease(props.row, coreNodeMode)">(prerelease)</template>
+                <template v-else-if="is_node_experimental(props.row, coreNodeMode)">(experimental)</template>
+                <template v-else-if="is_node_outdated(props.row, coreNodeMode)">(outdated)</template>
+                <template v-else>(obsolete)</template>
+              </small>
+            </template>
           </q-td>
           <q-td key="est_apy" :props="props">
             <template v-if="coreNodeMode">
@@ -345,6 +350,10 @@ export default {
           ]
         }
       }
+    },
+    node_versions_unavailable () {
+      return Object.values(this.latest_releases.ccn).some(x => x === null) ||
+        Object.values(this.latest_releases.crn).some(x => x === null)
     },
     ...mapState({
       account: (state) => state.account,

--- a/src/helpers/utilities.js
+++ b/src/helpers/utilities.js
@@ -103,11 +103,10 @@ export function normalizeValue (input, min, max, floor, ceil) {
  *
  * @param {string} url The URL to fetch
  * @param {string} cacheKey The LocalStorage key to use for cachinng (must be unique)
- * @param {number} cacheTime The time in ms to cache the data for (defaults to one hour)
- * @param {function} selector A selector function to select a part of the data to cache (defaults to the full payload)
+ * @param {number} cacheTime The time in ms to cache the data
  * @returns
  */
-export async function fetchAndCache (url, cacheKey, cacheTime = 1000 * 60 * 60 * 24) {
+export async function fetchAndCache (url, cacheKey, cacheTime) {
   const cached = localStorage.getItem(cacheKey)
   const now = Date.now()
   if (cached) {

--- a/src/helpers/utilities.js
+++ b/src/helpers/utilities.js
@@ -127,6 +127,7 @@ export async function fetchAndCache (url, cacheKey, cacheTime = 1000 * 60 * 60 *
       value
     })
     localStorage.setItem(cacheKey, toCache)
+    return value
   } catch (error) {
     console.error(`Failed to fetch ${url}`, error)
     if (cached) return JSON.parse(cached).value

--- a/src/helpers/utilities.js
+++ b/src/helpers/utilities.js
@@ -107,7 +107,7 @@ export function normalizeValue (input, min, max, floor, ceil) {
  * @param {function} selector A selector function to select a part of the data to cache (defaults to the full payload)
  * @returns
  */
-export async function fetchAndCache (url, cacheKey, cacheTime = 1000 * 60 * 60 * 24, defaultValue = null) {
+export async function fetchAndCache (url, cacheKey, cacheTime = 1000 * 60 * 60 * 24) {
   const cached = localStorage.getItem(cacheKey)
   const now = Date.now()
   if (cached) {
@@ -118,10 +118,9 @@ export async function fetchAndCache (url, cacheKey, cacheTime = 1000 * 60 * 60 *
     }
   }
 
-  let value = defaultValue
   try {
     const data = await fetch(url)
-    value = await data.json()
+    const value = await data.json()
 
     const toCache = JSON.stringify({
       cachedAt: now,
@@ -130,9 +129,8 @@ export async function fetchAndCache (url, cacheKey, cacheTime = 1000 * 60 * 60 *
     localStorage.setItem(cacheKey, toCache)
   } catch (error) {
     console.error(`Failed to fetch ${url}`, error)
+    if(cached) return JSON.parse(cached).value
   }
-
-  return value
 }
 
 /**

--- a/src/helpers/utilities.js
+++ b/src/helpers/utilities.js
@@ -129,7 +129,7 @@ export async function fetchAndCache (url, cacheKey, cacheTime = 1000 * 60 * 60 *
     localStorage.setItem(cacheKey, toCache)
   } catch (error) {
     console.error(`Failed to fetch ${url}`, error)
-    if(cached) return JSON.parse(cached).value
+    if (cached) return JSON.parse(cached).value
   }
 }
 

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -280,6 +280,7 @@ export default {
 
       statusSocket.onmessage = function (event) {
         const data = JSON.parse(event.data)
+        this.$store.commit('unset_network_errors', 'websockets')
 
         if (data.content === undefined || data.content.content === undefined) {
           return
@@ -304,6 +305,7 @@ export default {
       }.bind(this)
 
       statusSocket.onerror = function (err) {
+        this.$store.commit('set_network_errors', 'websockets')
         console.error('Socket encountered error: ', err.message, 'Closing socket')
         statusSocket.close()
       }

--- a/src/pages/Stake.vue
+++ b/src/pages/Stake.vue
@@ -401,6 +401,12 @@ export default {
         this.getLatestScores(),
         this.getLatestMetrics()
       ])
+      if (!ccn_versions || !crn_versions) {
+        this.$store.commit('set_network_errors', 'github')
+      }
+      if (!scores || !metrics) {
+        this.$store.commit('set_network_errors', 'scores')
+      }
       this.$store.commit('set_nodes_metadata', {
         ccn_versions,
         crn_versions,

--- a/src/pages/Stake.vue
+++ b/src/pages/Stake.vue
@@ -451,6 +451,7 @@ export default {
       // Dirty hack to avoid multiple updates on the first rendering
       let lastSocketMessage = Date.now()
       this.statusSocket.onmessage = function (event) {
+        this.$store.commit('unset_network_errors', 'websockets')
         const data = JSON.parse(event.data)
         if ((data.content !== undefined) &&
             (data.content.address === this.monitor_address) &&
@@ -473,6 +474,7 @@ export default {
 
       this.statusSocket.onerror = function (err) {
         console.error('Socket encountered error: ', err.message, 'Closing socket')
+        this.$store.commit('set_network_errors', 'websockets')
         this.statusSocket.close()
       }.bind(this)
     },

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -73,19 +73,21 @@ export default new Vuex.Store({
       ccn: { latest: '', prerelease: '', outdated: [] }
     },
     nodes_per_asn: {},
-    networkErrors: {
+    network_errors: {
       github: false,
-      score: false,
-      websocket: false
+      scores: false,
+      websockets: false
     }
   },
   mutations: {
+    set_network_errors (state, point_of_failure) {
+      state.network_errors[point_of_failure] = true
+    },
+    unset_network_errors (state, point_of_failure) {
+      state.network_errors[point_of_failure] = false
+    },
     set_nodes_metadata (state, { ccn_versions, crn_versions, scores, metrics }) {
       // merges all the metadata in a single mutation to avoid multiple re-renders
-      if (!ccn_versions || !crn_versions) {
-        state.networkErrors.github = true
-      }
-
       state.github_releases_metadata = {
         ccn: getLatestReleases(ccn_versions),
         crn: getLatestReleases(crn_versions)

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -72,11 +72,20 @@ export default new Vuex.Store({
       crn: { latest: '', prerelease: '', outdated: [] },
       ccn: { latest: '', prerelease: '', outdated: [] }
     },
-    nodes_per_asn: {}
+    nodes_per_asn: {},
+    networkErrors: {
+      github: false,
+      score: false,
+      websocket: false
+    }
   },
   mutations: {
     set_nodes_metadata (state, { ccn_versions, crn_versions, scores, metrics }) {
       // merges all the metadata in a single mutation to avoid multiple re-renders
+      if (!ccn_versions || !crn_versions) {
+        state.networkErrors.github = true
+      }
+
       state.github_releases_metadata = {
         ccn: getLatestReleases(ccn_versions),
         crn: getLatestReleases(crn_versions)


### PR DESCRIPTION
# The fix
Issues fetching the Github API do not break the dispay of the page anymore. 

A warning is displayed if the API is unreachable and the version of the node is not marked as "latest/outdated/obsolete/..."
![Screenshot from 2023-05-24 12-49-12](https://github.com/aleph-im/aleph-account/assets/26065817/aff5147d-b2cb-43d1-bf69-9c6aad3c49aa)
![Screenshot from 2023-05-24 12-49-05](https://github.com/aleph-im/aleph-account/assets/26065817/bba34e69-6dcb-4e42-83e4-44cf4e9093f7)

## How to replicate

If you're fortunate enough to have a steady connection to the API, you can block the network request manually in your browser devtools (head over to the network tab, right click on the request to Github displayed as "releases", and select "block URL")

![Screenshot from 2023-05-24 12-50-17](https://github.com/aleph-im/aleph-account/assets/26065817/24e40e66-963e-4a4d-be5c-8d29948a6b5c)

Since this query is cached to avoid hitting Github rate limitting you might also have to clear your LocalStorage.