### PR TITLE
Fix: Broken IPFS pinning

### DIFF
--- a/src/pages/IPFSPin.vue
+++ b/src/pages/IPFSPin.vue
@@ -325,7 +325,7 @@ export default {
         await store.submit(this.account.address, {
           account: this.account,
           api_server: this.api_server,
-          file_hash: result.cid.string,
+          file_hash: result.cid.toString(),
           storage_engine: 'ipfs',
           channel: 'PINNING',
           extra_fields: {


### PR DESCRIPTION
The issue was caused to a change in the js-ipfs library. 

To retrieve a cid, we previously had to call `[obj].cid.string`, this property does not exist anymore, calling the generics `.toString()` instead.