### PR TITLE
Fix for node info modal not showing linked CRN

### DIFF
--- a/src/components/NodeInfo.vue
+++ b/src/components/NodeInfo.vue
@@ -184,7 +184,7 @@
           </div>
           <q-list v-if="node.resource_nodes.length">
             <q-item v-for="resource_node of node.resource_nodes" :key="resource_node">
-                <resource-node-name :node-hash="resource_node" />
+                <resource-node-name :node-hash="resource_node.hash" />
             </q-item>
           </q-list>
           <div v-else>


### PR DESCRIPTION
# The problem
![a](https://github.com/aleph-im/aleph-account/assets/26065817/0e8d2082-d307-4188-a9be-f7856561f2d4)

# The fix
![b](https://github.com/aleph-im/aleph-account/assets/26065817/66b99ff8-00dc-4921-a9e4-bc42f35142c3)
