### PR TITLE
Fix: Use a "1 message history" when opening a socket

### DIFF
--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -274,7 +274,7 @@ export default {
   methods: {
     async prepare_distributions_feed () {
       const statusSocket = new WebSocket(
-        `${this.ws_api_server}/api/ws0/messages?msgType=POST&contentTypes=staking-rewards-distribution&addresses=` +
+        `${this.ws_api_server}/api/ws0/messages?msgType=POST&history=1&contentTypes=staking-rewards-distribution&addresses=` +
         `${this.sender_address},${this.monitor_address}`
       )
 

--- a/src/pages/Stake.vue
+++ b/src/pages/Stake.vue
@@ -429,21 +429,17 @@ export default {
     },
     async prepare_nodes_feed () {
       this.statusSocket = new WebSocket(
-        `${this.ws_api_server}/api/ws0/messages?msgType=AGGREGATE&addresses=` +
+        `${this.ws_api_server}/api/ws0/messages?msgType=AGGREGATE&history=1&addresses=` +
         `${this.monitor_address}`
       )
 
-      // Dirty hack to avoid multiple updates on the first rendering
-      let lastSocketMessage = Date.now()
       this.statusSocket.onmessage = function (event) {
         this.$store.commit('unset_network_errors', 'websockets')
         const data = JSON.parse(event.data)
         if ((data.content !== undefined) &&
             (data.content.address === this.monitor_address) &&
             (data.content.key === 'corechannel') &&
-            (data.content.content.nodes !== undefined) &&
-            Date.now() - lastSocketMessage > 200) {
-          lastSocketMessage = Date.now()
+            (data.content.content.nodes !== undefined)) {
           this.$store.commit('set_nodes', data.content.content.nodes)
           this.$store.commit('set_resource_nodes', data.content.content.resource_nodes)
           this.$store.commit('merge_node_scores')


### PR DESCRIPTION
Since the version 0.5.0 of CCN we do not have to load the 10 latest message of a socket while establishing a connection. This prevents unecessary rerenders on the UI at first load. 